### PR TITLE
feat: Add alerts and reminder notification

### DIFF
--- a/src/components/BaseNotification.stories.js
+++ b/src/components/BaseNotification.stories.js
@@ -1,0 +1,48 @@
+import BaseNotification from './BaseNotification.vue'
+
+export default {
+  title: 'Notifications',
+  component: BaseNotification,
+}
+
+const StatusTemplate = (args) => ({
+  components: { BaseNotification },
+  setup() {
+    return { args }
+  },
+  template: `
+    <BaseNotification v-bind="args">
+      <template #title>
+       Poke poke, this is a gentle reminder about something shiny.
+      </template>
+      
+      In order to get the most out of this app, please adjust your phasers to stun and hold on tight to the handrails.
+    </BaseNotification>
+  `,
+})
+
+export const Status = StatusTemplate.bind({})
+Status.args = {
+  role: 'status',
+}
+
+const AlertTemplate = (args) => ({
+  components: { BaseNotification },
+  setup() {
+    return { args }
+  },
+  template: `
+    <BaseNotification v-bind="args">
+      <template #title>
+       Oops! This is an alert which will warn you that things have gone wonky!
+      </template>
+      
+      Please do brush your unicorn a little more thorougly, so that your unicorn will keep that glossy mane and coat we've come to know and love.
+    </BaseNotification>
+  `,
+})
+
+export const Alert = AlertTemplate.bind({})
+Alert.args = {
+  role: 'alert',
+}

--- a/src/components/BaseNotification.vue
+++ b/src/components/BaseNotification.vue
@@ -1,0 +1,35 @@
+<template>
+  <div :role="role" :class="theme" class="px-4 py-2 border-l-4">
+    <h2 class="font-bold">
+      <slot name="title" />
+    </h2>
+
+    <p class="leading-5">
+      <slot />
+    </p>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  role: {
+    type: String,
+    default: 'status',
+    validator(value) {
+      return ['status', 'alert'].includes(value)
+    },
+  },
+})
+
+const theme = computed(() => {
+  switch (props.role) {
+    case 'status':
+    default:
+      return ['bg-blue-100', 'text-blue-700', 'border-blue-500']
+    case 'alert':
+      return ['bg-yellow-100', 'text-red-700', 'border-yellow-400']
+  }
+})
+</script>

--- a/src/components/StepInput.vue
+++ b/src/components/StepInput.vue
@@ -3,7 +3,12 @@ import BaseLabel from './BaseLabel.vue';
 <template>
   <div class="flex flex-col justify-between">
     <BaseLabel :for="stepId" class="flex">
-      <span class="mr-9 sm:mr-14 lg:mr-16">
+      <span
+        class="mr-9 sm:mr-14 lg:mr-16"
+        :class="
+          hasError ? 'p-1 rounded-full outline outline-4 outline-red-700' : ''
+        "
+      >
         <StepNumber :stepNumber="stepNumber" />
       </span>
       <span>
@@ -15,6 +20,8 @@ import BaseLabel from './BaseLabel.vue';
     </BaseLabel>
 
     <BaseTextArea
+      :name="name"
+      required="true"
       :id="stepId"
       :modelValue="stepText"
       class="h-40 p-2 sm:h-64 lg:h-72"
@@ -36,6 +43,14 @@ const props = defineProps({
   stepText: {
     type: String,
     default: '',
+  },
+  name: {
+    type: String,
+    default: '',
+  },
+  hasError: {
+    type: Boolean,
+    default: false,
   },
 })
 


### PR DESCRIPTION
## Card
[Jira #50](https://deborahod.atlassian.net/browse/TTS-50)

## What this PR does...
- Adds a polite status to remind users who have just generated their first pitch that they should copy the resulting text
- Adds an alert status for error messages
- Checks for empty bio or job description fields before processing the form
- Adds a small indicator around the errant step (this is not in the Figma, but I will check with the designer)
- Removed mock initial input (we may consider adding it back as placeholder text)

## How to test...
0. Be on screenreader + keyboard
1. Navigate to app
2. Leave one or more of the fields blank
3. Activate the "generate" button
- Expect to hear the fields that are incorrect
- Expect your cursor to be put in the first incorrect field
- Expect to see the yellow "alert" area at the top of the form
4. Fix any errors
5. Activate the "generate" button
- Expect not to see the alert area
- Expect to see the blue reminder status after the pitches are done generating

## I learned...
Sometimes it is easier not to use third party library for validation 😊 